### PR TITLE
Remove set-stolen on alarm trigger

### DIFF
--- a/custom_components/biketrax/alarm_control_panel.py
+++ b/custom_components/biketrax/alarm_control_panel.py
@@ -72,7 +72,7 @@ class BikeTraxAlarmController(BikeTraxBaseEntity, AlarmControlPanelEntity):
         """Return the state of the device."""
         return (
             STATE_ALARM_TRIGGERED
-            if self.device.is_alarm_triggered or self.device.is_stolen
+            if self.device.is_guarded and self.device.is_alarm_triggered
             else STATE_ALARM_ARMED_HOME
             if self.device.is_guarded and self._is_home
             else STATE_ALARM_ARMED_AWAY
@@ -101,4 +101,6 @@ class BikeTraxAlarmController(BikeTraxBaseEntity, AlarmControlPanelEntity):
     async def async_alarm_trigger(self, code: str | None = None) -> None:
         """Send alarm trigger command."""
         if not self.coordinator.read_only:
-            await self.device.set_stolen(True)
+            # There is not really a possibility to trigger an alarm, so at
+            # least enable it.
+            await self.device.set_guarded(True)


### PR DESCRIPTION
Marking the device as stolen when the alarm is enabled would mark it as triggered, which might not be the case.

The same 'functionality' can be recreated using automations, so it is up to the end-user to enable this or not.