### PR TITLE
Fix compatibility with 2023.5

### DIFF
--- a/custom_components/biketrax/__init__.py
+++ b/custom_components/biketrax/__init__.py
@@ -84,7 +84,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     entry.async_on_unload(hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, _stop))
 
     # Set up all platforms.
-    hass.config_entries.async_setup_platforms(entry, PLATFORMS)
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     return True
 


### PR DESCRIPTION
The async_setup_platforms was deprecated some time ago. This replaces it with an equivalent.