### PR TITLE
Migrate to new const data types

### DIFF
--- a/custom_components/biketrax/device_tracker.py
+++ b/custom_components/biketrax/device_tracker.py
@@ -6,7 +6,7 @@ import logging
 from typing import Literal
 
 from aiobiketrax import Device
-from homeassistant.components.device_tracker import SOURCE_TYPE_GPS
+from homeassistant.components.device_tracker import SourceType
 from homeassistant.components.device_tracker.config_entry import TrackerEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
@@ -83,7 +83,7 @@ class BikeTraxDeviceTracker(BikeTraxBaseEntity, TrackerEntity):
     @property
     def source_type(self) -> Literal["gps"]:
         """Return the source type, e.g. gps or router, of the device."""
-        return SOURCE_TYPE_GPS
+        return SourceType.GPS
 
     @property
     def extra_state_attributes(self):

--- a/custom_components/biketrax/sensor.py
+++ b/custom_components/biketrax/sensor.py
@@ -14,12 +14,7 @@ from homeassistant.components.sensor import (
     SensorStateClass,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import (
-    LENGTH_KILOMETERS,
-    LENGTH_METERS,
-    PERCENTAGE,
-    SPEED_KILOMETERS_PER_HOUR,
-)
+from homeassistant.const import PERCENTAGE, UnitOfLength, UnitOfSpeed
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -63,7 +58,7 @@ SENSOR_TYPES: tuple[BikeTraxSensorEntityDescription, ...] = (
         icon="mdi:speedometer",
         key="total_distance",
         name="Total distance",
-        native_unit_of_measurement=LENGTH_KILOMETERS,
+        native_unit_of_measurement=UnitOfLength.KILOMETERS,
         state_class=SensorStateClass.TOTAL_INCREASING,
     ),
     BikeTraxSensorEntityDescription(
@@ -72,7 +67,7 @@ SENSOR_TYPES: tuple[BikeTraxSensorEntityDescription, ...] = (
         icon="mdi:speedometer",
         key="speed",
         name="Current speed",
-        native_unit_of_measurement=SPEED_KILOMETERS_PER_HOUR,
+        native_unit_of_measurement=UnitOfSpeed.KILOMETERS_PER_HOUR,
         state_class=SensorStateClass.MEASUREMENT,
     ),
     BikeTraxSensorEntityDescription(
@@ -107,7 +102,7 @@ SENSOR_TYPES: tuple[BikeTraxSensorEntityDescription, ...] = (
         icon="mdi:map-marker-distance",
         key="geofence_radius",
         name="Auto alarm geofence radius",
-        native_unit_of_measurement=LENGTH_METERS,
+        native_unit_of_measurement=UnitOfLength.METERS,
     ),
     BikeTraxSensorEntityDescription(
         coordinator=DATA_DEVICE,


### PR DESCRIPTION
As of HA Core 2025.1 following consts will deprecate:

- `SOURCE_TYPE_GPS`
- `LENGTH_KILOMETERS`
- `LENGTH_METERS`
- `SPEED_KILOMETERS_PER_HOUR`

see HA logs:
```
2024-03-06 08:19:38.275 WARNING (MainThread) [homeassistant.components.device_tracker] SOURCE_TYPE_GPS was used from biketrax, this is a deprecated constant which will be removed in HA Core 2025.1. Use SourceType.GPS instead, please create a bug report at https://www.github.com/basilfx/homeassistant-biketrax/issues
2024-03-06 08:19:38.348 WARNING (MainThread) [homeassistant.components.device_tracker] SOURCE_TYPE_GPS was used from biketrax, this is a deprecated constant which will be removed in HA Core 2025.1. Use SourceType.GPS instead, please create a bug report at https://www.github.com/basilfx/homeassistant-biketrax/issues
2024-03-06 08:19:38.510 WARNING (MainThread) [homeassistant.const] LENGTH_KILOMETERS was used from biketrax, this is a deprecated constant which will be removed in HA Core 2025.1. Use UnitOfLength.KILOMETERS instead, please create a bug report at https://www.github.com/basilfx/homeassistant-biketrax/issues
2024-03-06 08:19:38.571 WARNING (MainThread) [homeassistant.const] LENGTH_METERS was used from biketrax, this is a deprecated constant which will be removed in HA Core 2025.1. Use UnitOfLength.METERS instead, please create a bug report at https://www.github.com/basilfx/homeassistant-biketrax/issues
2024-03-06 08:19:38.663 WARNING (MainThread) [homeassistant.const] SPEED_KILOMETERS_PER_HOUR was used from biketrax, this is a deprecated constant which will be removed in HA Core 2025.1. Use UnitOfSpeed.KILOMETERS_PER_HOUR instead, please create a bug report at https://www.github.com/basilfx/homeassistant-biketrax/issues
```