### PR TITLE
Ensure device identifier is a string

### DIFF
--- a/custom_components/biketrax/__init__.py
+++ b/custom_components/biketrax/__init__.py
@@ -117,11 +117,11 @@ class BikeTraxBaseEntity(CoordinatorEntity[BikeTraxDataUpdateCoordinator]):
         self.device = device
 
         self._attrs: dict[str, Any] = {
-            "id": self.device.id,
+            "id": str(self.device.id),
             "name": self.device.name,
         }
         self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, self.device.id)},
+            identifiers={(DOMAIN, str(self.device.id))},
             model=device.name,
             name=device.name,
         )

--- a/custom_components/biketrax/device_tracker.py
+++ b/custom_components/biketrax/device_tracker.py
@@ -58,8 +58,8 @@ class BikeTraxDeviceTracker(BikeTraxBaseEntity, TrackerEntity):
         """Initialize the tracker."""
         super().__init__(coordinator, device)
 
-        self._attr_unique_id = device.id
         self._attr_name = device.name
+        self._attr_unique_id = f"{device.id}-location"
 
     @property
     def battery_level(self) -> int | None:


### PR DESCRIPTION
The device identifier is an integer, which made the unique an integer as well. It should have been a string to begin with. This will be a breaking change, because the unique identifiers will change