### PR TITLE
async_write_ha_state must not be awaited

### DIFF
--- a/custom_components/biketrax/switch.py
+++ b/custom_components/biketrax/switch.py
@@ -106,10 +106,10 @@ class BikeTraxBinarySensor(BikeTraxBaseEntity, SwitchEntity):
         """Turn the entity on."""
         if not self.coordinator.read_only:
             await self.entity_description.set_fn(self.device, True)
-            await self.async_write_ha_state()
+            self.async_write_ha_state()
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the entity off."""
         if not self.coordinator.read_only:
             await self.entity_description.set_fn(self.device, False)
-            await self.async_write_ha_state()
+            self.async_write_ha_state()


### PR DESCRIPTION
This prevented HASS from updating the switch state after toggling.