### PR TITLE
Release v2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
-## v2.0.0b1
-Unreleased
+## v2.0.0
+Released 21 May 2024
 
 Highlights:
 * Updated: upgrade to aiobiketrax v1.3.0 to address several API changes.
@@ -10,7 +10,9 @@ Highlights:
 * Fixed: use new const data types for units and data sources.
 * Fixed: switch entities could not be toggled.
 
-The full list of commits can be found [here](https://github.com/basilfx/homeassistant-biketrax/compare/v1.1.2...v2.0.0b1).
+The full list of commits can be found [here](https://github.com/basilfx/homeassistant-biketrax/compare/v1.1.2...v2.0.0).
+
+This release supersedes v2.0.0b1.
 
 ## v1.1.2
 Released 1 January 2024

--- a/custom_components/biketrax/manifest.json
+++ b/custom_components/biketrax/manifest.json
@@ -11,6 +11,6 @@
   "loggers": ["aiobiketrax"],
   "requirements": ["aiobiketrax==1.3.0"],
   "ssdp": [],
-  "version": "2.0.0b1",
+  "version": "2.0.0",
   "zeroconf": []
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ profile = "black"
 
 [tool.poetry]
 name = "homeassistant-biketrax"
-version = "2.0.0b1"
+version = "2.0.0"
 description = "Custom component for the PowUnity BikeTrax integration for Home Assistant."
 authors = ["Bas Stottelaar <basstottelaar@gmail.com>"]
 package-mode = false


### PR DESCRIPTION
Be aware of the breaking change. Due to a fix w.r.t. entity identifiers, the device must be removed and re-added. The identifiers will remain the same, but their underlying unique identifier changed from integer to string.